### PR TITLE
filebrowser pagination/infinite scrolling fix

### DIFF
--- a/CSS/themes/filebrowser/filebrowser-base.css
+++ b/CSS/themes/filebrowser/filebrowser-base.css
@@ -18,7 +18,6 @@
     html {
         height: 100%;
         width: 100%;
-        overflow: hidden;
     }
     body {
         overflow-y: auto;


### PR DESCRIPTION
Removed 'overflow: hidden;' to fix pagination/infinite scrolling issue
in filebrowser.